### PR TITLE
BugFix: Argument List Mismatch

### DIFF
--- a/magick.lisp
+++ b/magick.lisp
@@ -563,7 +563,7 @@
   ((wand magick-wand) (comment magick-string))
   :check-error wand)
 (defmagickfun "MagickCompositeImage" :boolean
-  ((wand magick-wand) (src magick-wand) (compose composite-operator)
+  ((wand magick-wand) (src magick-wand) (compose composite-operator) (clip-to-self :boolean)
    (x :long) (y :long))
   :check-error wand)
 (defmagickfun "MagickConstituteImage" :boolean


### PR DESCRIPTION
```magick:composite-image``` not working due to mismatch in number of arguments.
Original MagickWand C API:
![2024-06-22T19-55-1719066333](https://github.com/ruricolist/lisp-magick-wand/assets/60106638/20457fcb-a4ec-4f9a-b1e2-18c2810a3089)
Fixed missing ```clip_to_self``` argument.
